### PR TITLE
py: modify object struct to empty

### DIFF
--- a/py/object.go
+++ b/py/object.go
@@ -26,7 +26,7 @@ import (
 
 // Object represents a Python object.
 type Object struct {
-	Unused [8]byte
+	Unused [0]byte
 }
 
 // llgo:link (*Object).DecRef C.Py_DecRef


### PR DESCRIPTION
### Overview
This PR changes the `py.Object` structure definition to an empty structure. which clarifies that LLGo treats Python objects managed by the C runtime as references, rather than storing the specific memory address of Python object in actual structure field.

This definition change supports multiple inheritance via structure embedding in LLGo. The design can be found at https://github.com/goplus/llpyg/pull/21, and the implementation can be found at https://github.com/goplus/llgo/pull/1289.

### Major Changes
source code:
```go
// Object represents a Python object.
type Object struct {
	Unused [8]byte
}
```
target code:

```go
// Object represents a Python object.
type Object struct {
	Unused [0]byte
}
```
Changing the field size to 0 is more clear than deleting the field and is consistent with the established pattern of the warehouse, such as `c/os/dir.go`:
```go
type DIR struct {
	Unused [0]byte
}
```